### PR TITLE
feat: Jira Issues can optionally include brackets

### DIFF
--- a/src/checks/missing_jira_issue_key.rs
+++ b/src/checks/missing_jira_issue_key.rs
@@ -15,7 +15,8 @@ You can fix this by adding a key like `JRA-123` to the commit message" ;
 pub const ERROR: &str = "Your commit message is missing a JIRA Issue Key";
 
 lazy_static! {
-    static ref RE: regex::Regex = regex::Regex::new(r"(?m)(^| )[A-Z]{2,}-[0-9]+( |$)").unwrap();
+    static ref RE: regex::Regex =
+        regex::Regex::new(r"(?m)(^| )\[?[A-Z]{2,}-[0-9]+\]?(| |$)").unwrap();
 }
 
 pub fn lint(commit_message: &CommitMessage<'_>) -> Option<Problem> {

--- a/src/checks/missing_jira_issue_key_test.rs
+++ b/src/checks/missing_jira_issue_key_test.rs
@@ -52,6 +52,29 @@ JR-123
 ",
         &None,
     );
+    test_has_missing_jira_issue_key(
+        "An example commit
+
+This is an example commit
+
+Relates-to: [JRA-123]
+",
+        &None,
+    );
+    test_has_missing_jira_issue_key(
+        "[JRA-123] An example commit
+
+This is an example commit
+",
+        &None,
+    );
+    test_has_missing_jira_issue_key(
+        "An example commit
+
+This is an [JRA-123] example commit
+",
+        &None,
+    );
 }
 
 #[test]


### PR DESCRIPTION
When using Jira integrations the issue numbers are matched as long as the reference is detectable.

This included: `[JRA-123]` vs `JRA-123`.

Supporting this gives greater flexibility, particularly for users familiar with other issue trackers (e.g pivotal tracker) where the `[]` are required.

`just fmt lint test` has already been run